### PR TITLE
+ add get Window instance by BrowserWindow instance's id attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ Returns the `window` instance of the specified window
 	win.resize(300, 200).restore();
 ```
 
+### `getById( id )`
+Returns the `window` instance of the specified window by BrowserWindow instance's id attribute
+```
+	var win = windowManager.getById(1);
+	win.close();
+```
+
 ### `getCurrent()`
 Returns the `Window` instance of the currently-under-focus window
 ```

--- a/index.js
+++ b/index.js
@@ -899,20 +899,26 @@
         },
 
         /**
+         * Get a window instance, by BrowserWindow instance id
+         */
+        getById: function(id) {
+            var instance;
+            _.each(this.windows, function(window){
+                if(window.object.id === id){
+                    instance = window;
+                }
+            });
+            return instance;
+        },
+
+        /**
          * Fetches the currently-under-focus window
          * */
         'getCurrent': function(){
             var thisWindow = BrowserWindow.getFocusedWindow();
             if(!thisWindow) return false;
 
-            var current;
-            _.each(this.windows, function(window){
-                if(window.object.id == thisWindow.id){
-                    current = window;
-                }
-            });
-
-            return current;
+            return this.getById(thisWindow.object.id);
         },
 
         /**


### PR DESCRIPTION
I use windowManger.getCurrent method in render process,  but get false
```
let win = require('electron').remote.require('electron-window-manager).getCurrent()
console.log(win) // print false
```
after add getById method
```
let id = require('electron').remote.getCurrentWindow().id
let win = require('electron').remote.require('electron-window-manager').getById(id)
if (win.name === 'winName') {
    // do something
}
```